### PR TITLE
Fix hero section UI and GitHub stats

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,13 +155,8 @@
                     <div class="container-content">
                         <div class="github-status">
                             <div class="status-content">
-                                <div class="status-indicator">
-                                    <div class="status-dot"></div>
-                                </div>
-                                <div class="status-text">
-                                    <h4>GitHub Status</h4>
-                                    <p class="status-subtitle">Active Developer</p>
-                                </div>
+                                <img src="https://github-readme-stats.vercel.app/api?username=akshaykarthicks&show_icons=true&theme=transparent&hide_border=true&rank_icon=github&card_width=400" alt="Akshay Karthick's GitHub Stats" />
+                                <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=akshaykarthicks&layout=compact&theme=transparent&hide_border=true" alt="Akshay Karthick's Top Languages" />
                             </div>
                         </div>
                     </div>

--- a/styles.css
+++ b/styles.css
@@ -574,6 +574,22 @@ main {
   background: rgba(255, 255, 255, 0.12);
 }
 
+/* Remove background and effects from social links container */
+.grid-container.div8 {
+    background: transparent;
+    border: none;
+    backdrop-filter: none;
+    box-shadow: none;
+    cursor: default;
+}
+
+.grid-container.div8:hover {
+    transform: none;
+    background: transparent;
+    box-shadow: none;
+    border-color: transparent;
+}
+
 .card-content {
   display: flex;
   flex-direction: column;
@@ -1082,7 +1098,7 @@ main {
   gap: var(--space-sm);
   padding: var(--space-sm);
   border-radius: var(--border-radius);
-  background: rgba(255, 255, 255, 0.05);
+  background: transparent;
   transition: all var(--animation-duration) var(--animation-timing);
   min-width: 80px;
   text-align: center;
@@ -1115,11 +1131,11 @@ main {
 }
 
 /* Tech Icon Colors */
-.tech-icon.django i { color: #0c4b33; }
+.tech-icon.django i { color: #44B78B; }
 .tech-icon.python i { color: #3776ab; }
 .tech-icon.html i { color: #e34f26; }
 .tech-icon.css i { color: #1572b6; }
-.tech-icon.github i { color: #333; }
+.tech-icon.github i { color: #ffffff; }
 .tech-icon.react i { color: #61dafb; }
 .tech-icon.docker i { color: #2496ed; }
 .tech-icon.postgresql i { color: #336791; }


### PR DESCRIPTION
This commit addresses three issues in the hero section:

1. Removes the background from the social links container, leaving only the circular icons.
2. Removes the grey background from the tech stack icons and updates the colors of the Django and GitHub icons for better visibility on a dark theme.
3. Replaces the static 'GitHub Status' text with dynamic images from the github-readme-stats service to show live user statistics.